### PR TITLE
Port Syslog RFC5424 format page to new docs site

### DIFF
--- a/docs/incidents/incident-objects.md
+++ b/docs/incidents/incident-objects.md
@@ -941,7 +941,7 @@ Human readable timestamp of the request eg. `2020-01-30 09:56:37 UTC+0000` <br><
   </div>
 </div> 
 
-## MSSQL Login Attempt
+## MySQL Login Attempt
 Triggered by an authentication attempt against the MySQL service.
 
 The client sends a hashed password, not a cleartext password. The Canary will try crack the hash with passwords one might expect in a brute-force.

--- a/docs/syslog/rfc5424.md
+++ b/docs/syslog/rfc5424.md
@@ -1,0 +1,551 @@
+# Syslog Example Logs
+
+Your Canary Console can be configured to send alerts via Syslog. We support the RFC5424 format for marking up Syslog lines with semantic information. RFC5424 is supported by most Syslog sinks; in the event yours doesn't support RFC5424 instead your alerts can be sent in a custom text-based format. If you'd like to configure Syslog support on your Console, please contact support.
+
+## Basic Structure
+
+
+Every RFC5424 log line has this basic structure:
+
+```
+<$PRI>$VER $TIMESTAMP $HOSTNAME $APPNAME $PROCID $MSGID $STRUCTURED_DATA
+```
+
+::: attribute-details
+
+**PRI**
+Syslog priority value, depending on the Syslog facility and severity.
+               This is admin-configurable, but defaults to the `LOCAL0` facility with `EMERGENCY` severity.<br><br>
+**VER**
+Syslog version, currently `1`. <br><br>
+**TIMESTAMP**
+Alert timestamp, in the format `YYYY-MM-DD<T>HH:MM:SS.sssss+ZZ:ZZ`. Timestamps are always provided in the UTC zone. <br><br>
+**HOSTNAME**
+Local hostname of the Canary Console. This is fixed per customer and will not change. <br><br>
+**APPNAME**
+Fixed string `ThinkstCanary`. <br><br>
+**PROCID**
+Opaque numeric field, indicates source process ID <br><br>
+**MSGID**
+Type of message. Currently only one type is support `newincident`,
+               indicating a new incident has been created on the Canary Console.<br><br>
+**STRUCTURED_DATA**
+Alert data structured according to RFC5424<br><br>
+:::
+
+The structured data depends on the type of incident that's being reported. We include additional details for each incident type, and the contents of the additional details will depend on both the type of incident as well as how the attacker interacted with the service. Below we provide an example log line for each incident type, however it is not exhaustive in the additional details for each incident type. While the examples below are formatted to wrap neatly, the actual Syslog records don't contain newlines.
+
+## Structured Data
+
+The structured data consists of two structured data elements:
+
+1. BasicIncidentDetails
+2. AdditionalIncidentDetails
+
+Both structured data elements are bound to our unique constant private enterprise number `51136`.
+
+
+### BasicIncidentDetails
+
+The **BasicIncidentDetails** section contains following elements common to all incidents:<br><br>
+
+::: attribute-details
+
+**eventid**
+  Field identifying the type of incident. See the logtype field in the [incidents object](/incidents/incident-objects.html).<br><br>
+
+**CanaryID**
+  The unique constant identifier for a Canary. Also known as the `node_id`.<br><br>
+
+**CanaryIP**
+  The Canary's IP address at the time of the incident.<br><br>
+
+**CanaryLocation**
+  Contents of the Canary's location (description) field.<br><br>
+
+**CanaryName**
+  User-friendly name of the Canary.<br><br>
+
+**CanaryPort**
+  TCP or UDP port of the service which triggered the alert. Not always present.<br><br>
+
+**Description**
+  Text description of the incident.<br><br>
+
+**IncidentHash**
+  Unique identifier for this incident.<br><br>
+
+**ReverseDNS**
+  Hostname of the attacker's IP address, if available.<br><br>
+
+**SourceIP**
+  Attacker's IP address.<br><br>
+
+**Timestamp**
+  Time at which the incident was created.<br><br>
+
+:::
+### AdditionalIncidentDetails
+
+The contents of the **AdditionalIncidentDetails** section will vary depending on the type of incident. Its purpose is to provide additional context to the incident.
+
+
+## Example Syslog Entries
+
+
+Here we provide example Syslog entries that might be sent, in RFC5424 format. Each subheading is an incident type, and the block that follows is a Syslog message. Below each block is a link to more information on the attributes specific to that incident type.
+
+### Canary Disconnected
+
+```log
+<130>1 2018-08-13T15:24:15.672152+00:00 mycompany-com ThinkstCanary 6051 newincident
+[BasicIncidentDetails@51136 eventid="1004" CanaryName="intranet03.mycompany.com"
+Description="Canary Disconnected" Timestamp="2018-08-13 15:24:14 (UTC)"
+IncidentHash="7e90c25b733d48fc46ce257efef497e1" CanaryLocation="Rack22 above switch"
+SourceIP="" CanaryID="0000000018a22bf1"]
+
+[AdditionalIncidentDetails@51136 PreviousIP="192.168.1.69"]
+One of your Canaries (intranet03.mycompany.com) previously at 192.168.1.69 has disconnected.
+```
+
+
+Attribute description: [Canary Disconnected](/incidents/incident-objects.html#canary-disconnected).
+
+### Canary Reconnected
+
+
+```
+<130>1 2018-08-13T14:12:45.238658+00:00 mycompany-com ThinkstCanary 6051 newincident
+[BasicIncidentDetails@51136 eventid="1004" CanaryName="intranet03.mycompany.com"
+Description="Canary Reconnected" Timestamp="2018-06-19 07:07:30 (UTC)"
+IncidentHash="d0e47e37d0515e2b2b0765aaaa2d584e" CanaryLocation="Rack22 above switch"
+SourceIP="" CanaryID="0000000018a22bf1"]
+
+
+[AdditionalIncidentDetails@51136 PreviousIP="192.168.1.69"]
+One of your Canaries (intranet03.mycompany.com) previously at 192.168.1.69 has reconnected.
+```
+
+### Consolidated Network Port Scan
+
+```
+  <130>1 2018-08-13T13:50:35.127637+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="5007" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="hyphen-hyphen" Description="Consolidated Network Port Scan" CanaryPort="80"
+  Timestamp="2018-08-13 13:50:34 (UTC)" CanaryIP="192.168.1.29"
+  IncidentHash="c307d1830441cbb238c42eef88b024bf" CanaryLocation="DC 5, Rack 17, Blade E, Unit 2"
+  SourceIP="192.168.1.82" CanaryID="00027550afb6819c"]
+
+  [AdditionalIncidentDetails@51136 Source="192.168.1.82"
+  Incident="Consolidated Network Port Scan" Targets="192.168.1.29, 192.168.1.69"]
+  A portscan has been done on several of your canaries by the host 192.168.1.82.
+
+```
+
+Attribute description: [Consolidated Network Port Scan](/incidents/incident-objects.html#consolidated-network-port-scan).
+
+### Custom TCP Service Request
+
+```
+
+  <130>1 2018-08-13T13:32:13.416516+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="20001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="Custom TCP Service Request" CanaryPort="8001"
+  Timestamp="2018-08-13 13:32:13 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="26cb5305fefca8f6dd5a25618dd94b69" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 FunctionName="New Connection Made" FunctionData="" TCPBannerID="1"]
+  Custom TCP Service Request has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [Custom TCP Service Request](/incidents/incident-objects.html#custom-tcp-service-request).
+
+### FTP Login Attempt
+
+```
+
+  <130>1 2018-08-13T13:18:28.803233+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="2000" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="FTP Login Attempt" CanaryPort="21"
+  Timestamp="2018-08-13 13:18:28 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="1358e614a0eb2500208dd34ce61300ca" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 Username="admin" Password="password"]
+  FTP Login Attempt has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+
+```
+
+Attribute description: [FTP Login Attempt](/incidents/incident-objects.html#ftp-login-attempt).
+
+
+### Git Repository Clone Attempt
+
+```
+  <130>1 2018-08-13T13:33:27.671646+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="19001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="Git Repository Clone Attempt"
+  CanaryPort="9418" Timestamp="2018-08-13 13:33:27 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="e42ff3137f6c034c79b820cb92101809" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136] Git Repository Clone Attempt has been
+  detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [Git Repository Clone Attempt](/incidents/incident-objects.html#git-repository-clone-attempt).
+
+### HTTP login
+
+```
+  <130>1 2018-08-13T13:22:07.159097+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="3001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="HTTP Login Attempt" CanaryPort="80"
+  Timestamp="2018-08-13 13:22:07 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="09ea9afbd8fdab5cdfd76322c9436bdd" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 Username="admin" Password="admin" User-Agent="curl/7.54.0"]
+  HTTP Login Attempt has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [HTTP Login Attempt](/incidents/incident-objects.html#http-login-attempt).
+
+### HTTP Proxy Request
+
+```
+  <130>1 2018-08-13T13:22:41.146736+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="7001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="HTTP Proxy Request" CanaryPort="8080"
+  Timestamp="2018-08-13 13:22:40 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="4e232c109368b43b47166cca733e9aad" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 Username="proxy" URL="http://google.com/" Password="proxypass"
+  User-Agent="curl/7.54.0"] HTTP Proxy Request has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+
+```
+
+Attribute description: [HTTP Proxy Request](/incidents/incident-objects.html#http-proxy-request).
+
+### Host Port Scan
+
+```
+
+  <130>1 2018-08-13T14:40:54.238093+00:00 mycompany-com ThinkstCanary 7792 newincident
+  [BasicIncidentDetails@51136 eventid="5003" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="Host Port Scan" CanaryPort="256"
+  Timestamp="2018-08-13 14:40:53 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="0d105c8aafc12484f7363a415b8c63f8" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 PartialPorts="443, 80, 256, 1720, 445"]
+  Host Port Scan has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+### Microsoft SQL Server Login
+
+```
+
+  <130>1 2018-08-13T13:50:28.649855+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="9001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="MSSQL Login Attempt" CanaryPort="1433"
+  Timestamp="2018-08-13 13:50:28 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="6d46c8cae1854c5ee0983674213771d3" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 Username="admin" Password="pass"
+  Hostname="attacker.local"]
+  MSSQL Login Attempt has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [MSSQL Login Attempt](/incidents/incident-objects.html#mssql-login-attempt).
+
+### ModBus Request
+
+```
+  <130>1 2018-08-13T13:34:28.905941+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="18001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="ModBus Request" CanaryPort="502"
+  Timestamp="2018-08-13 13:34:28 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="dfc7b90a4d88315281b76283766e347b" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 Functioncode="17" Functionname="Report Slave ID"]
+  ModBus Request has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+
+```
+
+Attribute description: [ModBus Request](/incidents/incident-objects.html#modbus-request).
+
+### MySQL Login
+
+```
+  <130>1 2018-08-13T13:35:33.585011+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="8001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="MySQL Login Attempt" CanaryPort="3306"
+  Timestamp="2018-08-13 13:35:33 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="62275c71db5d67925163f7a20f7e3220" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 Username="user"
+  ClientHash="b4794dd3a41ea7bd904ef5bc366a71fab3ea6c9c"
+  Password="password" Salt="xiT{J|.i<92>y9>$b:/J"]
+  MySQL Login Attempt has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+
+```
+
+Attribute description: [MySQL Login Attempt](/incidents/incident-objects.html#mysql-login-attempt).
+
+
+### Nmap NULL Scan
+
+```
+  <130>1 2018-08-13T13:33:02.192002+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="5005" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="NMAP NULL Scan Detected" CanaryPort="3306"
+  Timestamp="2018-08-13 13:33:02 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="a0ac716679dc47a19346236c47598595" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136] NMAP NULL Scan Detected has been detected against
+  one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [NMAP NULL Scan](/incidents/incident-objects.html#nmap-null-scan).
+
+### Nmap FIN Scan
+
+```
+  <130>1 2018-08-13T13:32:53.697117+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="5008" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="NMAP FIN Scan Detected" CanaryPort="993"
+  Timestamp="2018-08-13 13:32:53 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="8fd5f15a5d1ad3e4d9ef40a97b8d36a8" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136] NMAP FIN Scan Detected has been detected against
+  one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [NMAP FIN Scan](/incidents/incident-objects.html#nmap-fin-scan).
+
+### Nmap OS Scan
+
+```
+ <130>1 2018-08-13T13:32:36.910136+00:00 mycompany-com ThinkstCanary 6051 newincident
+ [BasicIncidentDetails@51136 eventid="5004" ReverseDNS="attacker.in.mycompany.com"
+ CanaryName="intranet03.mycompany.com" Description="NMAP OS Scan Detected" CanaryPort="21"
+ Timestamp="2018-08-13 13:32:36 (UTC)" CanaryIP="192.168.1.69"
+ IncidentHash="dc163f9dbf7dd35745d2e28995f89d68" CanaryLocation="Rack22 above switch"
+ SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+ [AdditionalIncidentDetails@51136] NMAP OS Scan Detected has been detected against
+ one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [NMAP OS Scan](/incidents/incident-objects.html#nmap-os-scan).
+
+### Nmap Xmas Scan
+
+
+```
+
+  <130>1 2018-08-13T13:32:46.469290+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="5006" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="NMAP XMAS Scan Detected" CanaryPort="3306"
+  Timestamp="2018-08-13 13:32:46 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="2d4298166ba5a2045915f5cff38f2ff7" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136] NMAP XMAS Scan Detected has been detected against
+  one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [NMAP XMAS Scan](/incidents/incident-objects.html#nmap-xmas-scan).
+
+### NTP Monlist Request
+
+```
+  <130>1 2018-08-13T13:34:58.739325+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="11001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="NTP Monlist Request" CanaryPort="123"
+  Timestamp="2018-08-13 13:34:58 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="6a58a52cc6388163cd223bc6746795f4" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 NTPCommand="monlist"]
+  NTP Monlist Request has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [NTP Monlist Request](/incidents/incident-objects.html#ntp-monlist-request).
+
+### Redis Command
+
+```
+  <130>1 2018-08-13T13:33:52.151406+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="21001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="Redis Command" CanaryPort="6379"
+  Timestamp="2018-08-13 13:33:51 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="f5fb29672cd13f30bb7e59351eed622e" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136]
+  Redis Command has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [Redis Command](/incidents/incident-objects.html#redis-command).
+
+### SIP Request
+
+```
+  <130>1 2018-08-13T13:54:36.259297+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="15001" ReverseDNS="rogue.phone.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="SIP Request" CanaryPort="5060"
+  Timestamp="2018-08-13 13:54:36 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="c8994d29e39632c1cf2ae12b7398f3f2" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.30" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 content-length="0" expires="60"
+  from="<sip:sipuser@192.168.1.69;transport=UDP>;tag=3864bd77"
+  via="SIP/2.0/UDP 129.205.140.132:46849;branch=z9hG4bK-524287-1---6232828c8a6a35b5;received=192.168.1.30;rport"
+  allow-events="presence, kpml, talk" user-agent="Zoiper rv2.8.97-mod"
+  to="<sip:sipuser@192.168.1.69;transport=UDP>"
+  contact="<sip:sipuser@192.168.1.30:46849;rinstance=164258fa1b2705d4;transport=UDP>"
+  cseq="9 REGISTER" allow="INVITE, ACK, CANCEL, BYE, NOTIFY, REFER, MESSAGE, OPTIONS, INFO, SUBSCRIBE"
+  max-forwards="70" call-id="56XIpFpoDXyQ-J8N3qmd_g.."]
+  SIP Request has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [SIP Request](/incidents/incident-objects.html#sip-request).
+
+### SNMP
+
+```
+  <130>1 2018-08-13T13:21:23.127789+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="13001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="SNMP Request" CanaryPort="161"
+  Timestamp="2018-08-13 13:21:22 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="699378356f7d605da4e47822d91de89c" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 CommunityString="public" OIDs="1.3.6.1.2.1.1"]
+  SNMP Request has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [SNMP Request](/incidents/incident-objects.html#snmp-request).
+
+
+### SSH (Password login)
+
+```
+  <130>1 2018-08-13T14:23:07.413167+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="4002" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet02.mycompany.com" Description="SSH Login Attempt" CanaryPort="22"
+  Timestamp="2018-08-13 14:23:07 (UTC)" CanaryIP="192.168.1.29"
+  IncidentHash="163532a3093341608393cab25c132c69"
+  CanaryLocation="DC 5, Rack 17, Blade E, Unit 2" SourceIP="192.168.1.82" CanaryID="00027550afb6819c"]
+
+  [AdditionalIncidentDetails@51136 Username="root" Password="hello"]
+  SSH Login Attempt has been detected against one of your Canaries
+  (intranet02.mycompany.com) at 192.168.1.29.
+```
+
+Attribute description: [SSH Login Attempt](/incidents/incident-objects.html#ssh-login-attempt).
+
+### SSH (key-based login)
+
+```
+  <130>1 2018-08-13T14:16:01.152948+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="4002" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet02.mycompany.com" Description="SSH Login Attempt" CanaryPort="22"
+  Timestamp="2018-08-13 14:16:00 (UTC)" CanaryIP="192.168.1.29"
+  IncidentHash="ef1e4bac00843e2b30d1ddc052a76186" CanaryLocation="DC 5, Rack 17, Blade E, Unit 2"
+  SourceIP="192.168.1.82" CanaryID="00027550afb6819c"]
+
+  [AdditionalIncidentDetails@51136 Username="root"
+  Key="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2GjEQNXUTt4SHks1elgP3wSJ31M+5TWK+TXBCiijgezKjWww963wPapHfzhmXUHRS+tUSc3HhNlZ1utkj9T9RsMDdvRfCOFsML13L66kkkv/r5GF8dBGa9305ESnq1/o5CuzStF2+l95yz9W0h1F0fJM4GVFigY3Q3lLEsPVpLNp0hp+MwWo7HooAvSaX+2pPBXVKKpzdMRAYmzXqH1OTztQxTJOIoDfFz6kkqSrpzjAgnw9a86BRcpOaTYFkG+WEe3l5JBgKqg+dvJ6+Pv96OmlJt05YL+kp+TjYX80uCHk0SuAEAWkhXdks2ifSxGHBP9JeR5G0ulkL35/uhmCZ"]
+  SSH Login Attempt has been detected against one of your Canaries
+  (intranet02.mycompany.com) at 192.168.1.29.
+```
+
+Attribute description: [SSH Login Attempt](/incidents/incident-objects.html#ssh-login-attempt).
+
+### Telnet Login Attempt
+
+
+```
+  <130>1 2018-08-13T13:19:51.015053+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="6001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="Telnet Login Attempt" CanaryPort="23"
+  Timestamp="2018-08-13 13:19:50 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="c467345a6e41651cc6c6398ece27d8ef" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 Username="supervisor" Password="password123"]
+  Telnet Login Attempt has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [Telnet Login Attempt](/incidents/incident-objects.html#telnet-login-attempt).
+
+### TFTP Request
+
+
+```
+  <130>1 2018-08-13T13:25:37.021004+00:00 mycompany-com ThinkstCanary 6051 newincident [BasicIncidentDetails@51136 eventid="10001" ReverseDNS="attacker.in.mycompany.com" CanaryName="intranet03.mycompany.com" Description="TFTP Request" CanaryPort="69" Timestamp="2018-08-13 13:25:36 (UTC)" CanaryIP="192.168.1.69" IncidentHash="6e79bb7c281780a5130c1a54b64759a0" CanaryLocation="Rack22 above switch" SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"][AdditionalIncidentDetails@51136 Action="READ" Filename="/etc/passwd"] TFTP Request has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [TFTP Request](/incidents/incident-objects.html#tftp-request).
+
+### VNC Login Attempt
+
+```
+  <130>1 2018-08-13T13:28:58.532033+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="12001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="VNC Login Attempt" CanaryPort="5900"
+  Timestamp="2018-08-13 13:28:58 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="77fae8e893ea04d5fb6c72b177779131" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
+
+  [AdditionalIncidentDetails@51136 VNCServerChallenge="49cad65c054ce8f1b9b6495919c98f49"
+  VNCClientResponse="3b049ba5d7e44732a7513a834c899486"
+  VNCPassword="<Password was not in the common list>"] VNC Login Attempt has been detected
+  against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [VNC Login Attempt](/incidents/incident-objects.html#vnc-login-attempt).
+
+### Shared File Opened
+
+```
+  <130>1 2018-08-13T13:56:39.819028+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="5000" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet02.mycompany.com" Description="Shared File Opened"
+  CanaryPort="445" Timestamp="2018-08-13 13:56:39 (UTC)" CanaryIP="192.168.1.29"
+  IncidentHash="7d2e642a5974173de0214e66427de22c" CanaryLocation="DC 5, Rack 17, Blade E, Unit 2"
+  SourceIP="192.168.1.82" CanaryID="00027550afb6819c"]
+
+  [AdditionalIncidentDetails@51136 User="guest" Filename="Sales Brochure 2017.pdf"]
+  Shared File Opened has been detected against one of your Canaries
+  (intranet02.mycompany.com) at 192.168.1.29.
+```
+
+Attribute description: [Shared File Opened](/incidents/incident-objects.html#shared-file-opened).
+
+
+
+


### PR DESCRIPTION
In the previous incarnation of the Console documentation, this page laid
out the Syslog message format. This is an initial port of that content
to make it publicly available again.