### PR TITLE
Update the API for saving SMS and email notifications

### DIFF
--- a/docs/console-settings/notification-settings.md
+++ b/docs/console-settings/notification-settings.md
@@ -105,7 +105,7 @@ endpoints:
       - name: clear
         required: false
         type: boolean
-        description: If set to true, clears the list of cellphone numbers
+        description: If set to true, clears the list of email addresses
     response: A JSON structure with result indicator.
 ---
 

--- a/docs/flocks-settings/notifications.md
+++ b/docs/flocks-settings/notifications.md
@@ -109,9 +109,13 @@ endpoints:
         type: string
         description: A valid flock_id
       - name: addresses
-        required: true
+        required: false
         type: string
         description: A comma separated list of valid email addresses
+      - name: clear
+        required: false
+        type: boolean
+        description: If set to true, clears the list of email addresses
     response: A JSON structure with result indicator.
   flock_email_use_global:
     name: Use Global for Notification Emails
@@ -237,9 +241,13 @@ endpoints:
         type: string
         description: A valid flock_id
       - name: addresses
-        required: true
+        required: false
         type: string
         description: A comma separated list of valid cellphone numbers
+      - name: clear
+        required: false
+        type: boolean
+        description: If set to true, clears the list of cellphone numbers
     response: A JSON structure with result indicator.
   flock_sms_use_global:
     name: Use Global for SMS Notifications


### PR DESCRIPTION
Update the API for saving SMS numbers and email address notifications
allowing the field to be cleared, for flock and global settings.