### PR TITLE
S3 tokens require source and log bucket to be specified

### DIFF
--- a/docs/canarytokens/actions.md
+++ b/docs/canarytokens/actions.md
@@ -66,7 +66,7 @@ endpoints:
       - name: s3_log_bucket
         required: false
         type: string
-        description: S3 bucket where logs will be stored (optional when creating aws-s3 tokens)
+        description: S3 bucket where logs will be stored (required when creating aws-s3 tokens)
       - name: aws_access_key
         required: false
         type: string

--- a/docs/canarytokens/actions.md
+++ b/docs/canarytokens/actions.md
@@ -62,7 +62,7 @@ endpoints:
       - name: s3_source_bucket
         required: false
         type: string
-        description: S3 bucket to monitor for access  (optional when creating aws-s3 tokens)
+        description: S3 bucket to monitor for access  (required when creating aws-s3 tokens)
       - name: s3_log_bucket
         required: false
         type: string


### PR DESCRIPTION
The log bucket and source bucket to monitor *must* be specified to make a token. The API will block requests which do not specify them.