### PR TITLE
Fix 404 in notifications.md

### DIFF
--- a/docs/flocks-settings/notifications.md
+++ b/docs/flocks-settings/notifications.md
@@ -272,7 +272,7 @@ endpoints:
 
 ::::: slot details
 
-Below are endpoints that allow you to configure your Email and SMS notification settings for a Flock. We do also have a section for [Webhooks](/flock-settings/webhooks.html) if you need to configure webhook settings.
+Below are endpoints that allow you to configure your Email and SMS notification settings for a Flock. We do also have a section for [Webhooks](/flocks-settings/webhooks.html) if you need to configure webhook settings.
 
 :::::
 


### PR DESCRIPTION
STR:
- go to https://docs.canary.tools/flocks-settings/notifications.html
- click on webhook url

<img width="395" alt="Captura de ecrã 2023-02-10, às 16 44 57" src="https://user-images.githubusercontent.com/29093946/218147823-72ccd9fe-f6b5-4a6a-8141-87e134488c72.png">

goes to https://docs.canary.tools/flock-settings/webhooks.html and returns error

correct url is - https://docs.canary.tools/flocks-settings/webhooks.html


this PR fixes that