### PR TITLE
Fix 404 in webhooks.md

### DIFF
--- a/docs/flocks-settings/webhooks.md
+++ b/docs/flocks-settings/webhooks.md
@@ -1071,7 +1071,7 @@ Have an MS Teams account and want us to pipe Flock notifications directly into y
 
 We currently don't expose the Slack add process via the API directly as it requires a multi-step process which includes Authenticating with Slack and granting permissions for the webhook to POST data to your channels.
 
-A step-by-step guide to adding a Slack webhook via the Console UI can be found [here](https://help.canary.tools/help/edit-delete-how-do-i-webhook-notifications).
+A step-by-step guide to adding a Slack webhook via the Console UI can be found [here](https://help.canary.tools/hc/en-gb/articles/360012819778-How-do-I-configure-Slack-Webhook-notifications-).
 
 ### List Slack Webhooks
 


### PR DESCRIPTION
STR:
- go to https://docs.canary.tools/flocks-settings/webhooks.html#slack-webhooks
- click on ''here''


<img width="898" alt="Captura de ecrã 2023-02-10, às 16 59 51" src="https://user-images.githubusercontent.com/29093946/218151254-48b3610e-cefa-471d-b264-29793e461f53.png">

goes to https://help.canary.tools/help/edit-delete-how-do-i-webhook-notifications and returns 404

<img width="1200" alt="Captura de ecrã 2023-02-10, às 17 00 13" src="https://user-images.githubusercontent.com/29093946/218151328-d5dfa374-42b8-4e24-800b-ba0fb0e32397.png">

seems this is the correct url - https://help.canary.tools/hc/en-gb/articles/360012819778-How-do-I-configure-Slack-Webhook-notifications-


this PR fixes that
