### PR TITLE
Add details on Canarytoken memo character limit

### DIFF
--- a/docs/canarytokens/actions.md
+++ b/docs/canarytokens/actions.md
@@ -44,7 +44,7 @@ endpoints:
       - name: memo
         required: true
         type: string
-        description: A reminder that will be included in the alert to let you know where you placed this Canarytoken
+        description: A reminder that will be included in the alert to let you know where you placed this Canarytoken, limited to 10000 characters.
       - name: kind
         required: true
         type: string
@@ -250,7 +250,7 @@ endpoints:
       - name: memo
         required: true
         type: string
-        description: A reminder that will be included in the alert to let you know where you placed this Canarytoken
+        description: A reminder that will be included in the alert to let you know where you placed this Canarytoken, limited to 10000 characters.
     response: A JSON structure with result indicator.
 ---
 


### PR DESCRIPTION
Update docs to include character limit for Canarytoken memo field:
<img width="471" alt="Screenshot 2023-03-23 at 15 11 54" src="https://user-images.githubusercontent.com/51328612/227215825-4c4a1dd2-3f36-456f-b1f5-558dc2eea6d3.png">
