### PR TITLE
Mark the flock_id as required for when a factory is created

### DIFF
--- a/docs/canarytokens/factory.md
+++ b/docs/canarytokens/factory.md
@@ -22,10 +22,9 @@ endpoints:
         type: string
         description: A valid auth token
       - name: flock_id
-        required: false
+        required: true
         type: string
-        default: "'flock:default'"
-        description: A valid flock_id (defaults to the [Default Flock](/guide/terminology.html#default-flock))
+        description: A valid flock_id
       - name: memo
         required: true
         type: string
@@ -59,8 +58,8 @@ endpoints:
       - name: flock_id
         required: false
         type: string
-        default: "'flock:default'"
-        description: A valid flock_id (defaults to the [Default Flock](/guide/terminology.html#default-flock))
+        default: "flock_id of factory"
+        description: A valid flock_id (defaults to the flock_id of the token factory)
       - name: memo
         required: true
         type: string
@@ -366,7 +365,7 @@ $ ls -l
 
 ``` bash
 curl https://EXAMPLE.canary.tools/api/v1/canarytoken/create_factory \
-  -d auth_token=EXAMPLE_AUTH_TOKEN \
+  -d auth_token=EXAMPLE_AUTH_TOKEN -d flock_id=flock:default \
   -d memo='Example Memo'
 ```
 
@@ -381,6 +380,7 @@ url = 'https://EXAMPLE.canary.tools/api/v1/canarytoken/create_factory'
 
 payload = {
   'auth_token': 'EXAMPLE_AUTH_TOKEN',
+  'flock_id': 'flock:default',
   'memo': 'Example Memo'
 }
 


### PR DESCRIPTION
New required flock_id when creating a token factory auth string
![Screenshot 2023-04-18 at 19 11 35](https://user-images.githubusercontent.com/89250089/232853205-d4f39d29-190e-4644-8e98-2f33c782973c.png)

Updated default message for the flock_id when creating a token using the factory
![Screenshot 2023-04-18 at 19 11 51](https://user-images.githubusercontent.com/89250089/232853267-f9fe81e7-7a66-4c1c-b63a-270bdb152539.png)
