### PR TITLE
Add after_id to audit trail fetch

### DIFF
--- a/docs/console/audit-trail.md
+++ b/docs/console/audit-trail.md
@@ -36,6 +36,11 @@ endpoints:
         type: string
         description: Only return logs that have a field matching this query term. '%20' should be used in place of any spaces between words.
 
+      - name: after_id
+        required: false
+        type: int
+        description: Return audit log entries whose ID is greater than the supplied ID. Mutually exclusive with `cursor`.
+
       - name: start_date
         required: false
         type: string 


### PR DESCRIPTION
## Proposed changes

Add the missing `after_id` parameter to the `audit_trail/fetch` endpoint docs.