### PR TITLE
Add `format` argument for `/api/v1/canaryvm/download` endpoint

### DIFF
--- a/docs/bird-management/virtual-canaries.md
+++ b/docs/bird-management/virtual-canaries.md
@@ -17,6 +17,7 @@ endpoints:
       - name: format
         required: false
         type: string
+        default: "vmx"
         description: "The format of the Virtual Canary archive. Options are: `vmx` and `ova`"
     response: A JSON Structure containing the download URL for the specified version of the CanaryVM image.
   canaryvm_download_seed:

--- a/docs/bird-management/virtual-canaries.md
+++ b/docs/bird-management/virtual-canaries.md
@@ -14,6 +14,10 @@ endpoints:
         required: true
         type: string
         description: A valid CanaryVM version
+      - name: format
+        required: false
+        type: string
+        description: "The format of the Virtual Canary archive. Options are: `vmx` and `ova`"
     response: A JSON Structure containing the download URL for the specified version of the CanaryVM image.
   canaryvm_download_seed:
     name: Download CanaryVM Image Seed Data


### PR DESCRIPTION
## Proposed changes

One of our awesome customers spotted that the `/api/v1/canaryvm/download` API endpoint has an undocumented optional argument `format`. This PR adds the missing arg to our docs:

<img width="900" alt="New docs for /api/v1/canaryvm/download" src="https://github.com/user-attachments/assets/eb89f80b-cb6d-4ec8-91f4-dea3847bd1e3" />


## Types of changes
- [x] Documentation Update
