### PR TITLE
Add custom_domain argument to endpoint to create Canarytokens using factory

### DIFF
--- a/docs/canarytokens/factory.md
+++ b/docs/canarytokens/factory.md
@@ -96,6 +96,12 @@ endpoints:
         required: false
         type: string
         description: Domain to check against (required when creating cloned-web tokens)
+
+      - name: custom_domain
+        required: false
+        type: string
+        description: Specifies the custom Canarytoken domain to use (that's already been linked to the Console) when creating a Canarytoken
+
       - name: browser_scanner_enabled
         required: false
         type: boolean


### PR DESCRIPTION
Documentation update to note the new `custom_domain` argument that can be used when creating Canarytokens with a factory.

Checked it renders as expected when deployed locally.