### PR TITLE
Add missing instances of required for Canarytoken create endpoints

### DIFF
--- a/docs/canarytokens/actions.md
+++ b/docs/canarytokens/actions.md
@@ -122,6 +122,7 @@ endpoints:
         description: Specifies the custom Canarytoken domain to use (that's already been linked to the Console) when creating a Canarytoken
 
       - name: doc
+        required: false
         type: file
         description: Upload MS Word Document to canarytoken; optionally used with MS Word Document (doc-msword) token. With curl use the following flag
                      `-F 'doc=@upload-me.docx; type=application/vnd.openxmlformats-officedocument.wordprocessingml.document'`
@@ -143,6 +144,7 @@ endpoints:
         description: A valid flock_id (defaults to the [Default Flock](/guide/terminology.html#default-flock))
 
       - name: pdf
+        required: false
         type: file
         description: Upload PDF file to canarytoken; optionally used with Adobe PDF canarytoken (pdf-acrobat-reader). With curl use the following flag
                     `-F pdf=@upload-me.pdf; type=application/pdf`

--- a/docs/canarytokens/factory.md
+++ b/docs/canarytokens/factory.md
@@ -129,10 +129,12 @@ endpoints:
         description: Image file (jpeg or png) that will be displayed on the Canarytokens URL (required when creating web-image tokens)
 
       - name: doc
+        required: false
         type: file
         description: Upload MS Word Document to canarytoken; optionally used with MS Word Document (doc-msword) token. With curl use the following flag
                      `-F 'doc=@upload-me.docx; type=application/vnd.openxmlformats-officedocument.wordprocessingml.document'`
       - name: pdf
+        required: false
         type: file
         description: Upload PDF file to canarytoken; optionally used with Adobe PDF canarytoken (pdf-acrobat-reader). With curl use the following flag
                     `-F pdf=@upload-me.pdf; type=application/pdf`


### PR DESCRIPTION
Minor change to add missing `required` field for some of the args passed when creating a Canarytoken.