### PR TITLE
Remove duplicate query field: expected_referrer

### DIFF
--- a/docs/canarytokens/factory.md
+++ b/docs/canarytokens/factory.md
@@ -87,11 +87,6 @@ endpoints:
         description: An image file for use with web-image tokens (request must be multipart/form-data encoded
                      if parameter is present, required when using web-image)
 
-      - name: expected_referrer
-        required: false
-        type: string
-        description: Expected domain to check against (required when creating cloned-css tokens)
-
       - name: cloned_web
         required: false
         type: string


### PR DESCRIPTION
## Proposed changes
`expected_referrer` is listed twice in the documentation for `/api/v1/canarytoken/factory/create`

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
