### PR TITLE
Add missing notification types to rfc5424 docs

### DIFF
--- a/docs/incidents/incident-objects.md
+++ b/docs/incidents/incident-objects.md
@@ -1248,8 +1248,20 @@ Triggered by a Canary reverting it's network settings after a settings push if i
 
 ::: attribute-details
 
+**Canary Status**
+The status of the canary after the rollback <br><br>
+**Erroneous network settings**
+The settings which changed, causing the rollback <br><br>
+**Restored network settings**
+The settings restored after the rollback <br><br>
 **Rollback time**
 The timestamp of the rollback eg. `1580378197` <br><br>
+**User**
+The user that deployed the erroneous settings <br><br>
+**timestamp**
+The timestamp of the incident eg. `1580378197` <br><br>
+**timestamp_std**
+Human readable timestamp of the incident eg. `2020-01-30 09:56:37 UTC+0000` <br><br>
 
 :::
 
@@ -1262,9 +1274,15 @@ The timestamp of the rollback eg. `1580378197` <br><br>
 ``` json
 <EVENT_DESCRIPTION> = "Network Settings Roll-back"
 <LOGTYPE> = "22011"
-<EVENT_DICT> = [
-                 "Rollbacktime: 1580378197"
-               ]
+<EVENT_DICT> = {
+                 "Canary Status": "Canary is currently ONLINE.",
+                 "Erroneous network settings": "Canary IP address: 192.168.1.114; Netmask: 255.255.255.0; Gateway: 192.168.1.1; DNS server 1: 8.7.6.5; DNS server 2: 8.7.6.5; DHCP: Disabled",
+                 "Restored network settings": "Canary IP address: 192.168.1.206; DHCP: Enabled",
+                 "Rollback time": "1746085804.66",
+                 "User": "user",
+                 "timestamp": 1746085866,
+                 "timestamp_std": "2025-05-01 07:51:06 UTC+0000"
+               }
 ```
 :::
   </div>

--- a/docs/incidents/incident-objects.md
+++ b/docs/incidents/incident-objects.md
@@ -197,6 +197,35 @@ A string containing the changed settings. <br><br>
   </div>
 </div>
 
+## Flock Settings Changed
+
+<div class="section-container">
+  <div class="details-content">
+
+::: attribute-details
+
+**SETTINGS**
+A string containing the changed settings. <br><br>
+
+:::
+
+  </div>
+  <div class="example-content">
+
+<br>
+
+:::  api-response
+``` json
+<EVENT_DESCRIPTION> = "Console Settings Changed"
+<LOGTYPE> = "23003"
+<EVENT_DICT> ={
+                "SETTINGS": "enable_emails_notifications=True\nModified by user"
+            }
+```
+:::
+  </div>
+</div>
+
 ## Canarytokens
 
 Most Canarytokens make use of `HTTP` and `DNS` as their underlying communication channel.

--- a/docs/syslog/rfc5424.md
+++ b/docs/syslog/rfc5424.md
@@ -4,7 +4,6 @@ Your Canary Console can be configured to send alerts via Syslog. We support the 
 
 ## Basic Structure
 
-
 Every RFC5424 log line has this basic structure:
 
 ```
@@ -43,7 +42,6 @@ The structured data consists of two structured data elements:
 2. AdditionalIncidentDetails
 
 Both structured data elements are bound to our unique constant private enterprise number `51136`.
-
 
 ### BasicIncidentDetails
 
@@ -89,78 +87,151 @@ The **BasicIncidentDetails** section contains following elements common to all i
 
 The contents of the **AdditionalIncidentDetails** section will vary depending on the type of incident. Its purpose is to provide additional context to the incident.
 
-
 ## Example Syslog Entries
 
-
 Here we provide example Syslog entries that might be sent, in RFC5424 format. Each subheading is an incident type, and the block that follows is a Syslog message. Below each block is a link to more information on the attributes specific to that incident type.
+
+### Canarytokens Incidents
+
+#### HTTP
+
+```
+  <130>1 2025-04-30T12:09:54.681299+00:00 mycompany-com ThinkstCanary 3545385 newincident
+  [BasicIncidentDetails@51136 Description="Web Bug Canarytoken triggered"
+  Timestamp="2025-04-30 12:07:53 (UTC)" Reminder="q" Token="d7a7phdpurh2vs8gs1jbniyhb"
+  SourceIP="192.168.1.97" IncidentHash="40a96cf3ba4596a81f18990143916b3c" eventid="17000"]
+
+  [AdditionalIncidentDetails@51136
+  Abbr="SAST" Accept="text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+  Accept-Encoding="gzip, deflate" Accept-Language="en-GB,en-US;q=0.9,en;q=0.8,ro;q=0.7"
+  BackgroundContext="You have had 214 incidents from 192.168.1.97 previously."
+  Browser="Chrome" Cache-Control="max-age=0" City="Cape Town" Connection="keep-alive"
+  ContinentCode="AF" Country="South Africa" CountryCode="ZA" CountryCode3="ZAF" CurrencyCode="ZAR"
+  Date="2025-04-30" DstPort="80" Enabled="1" Host="123456789abe[.\]o3n[.\]io" HostDomain=""
+  Hostname="" Id="Africa/Johannesburg" Installed="1" Ip="192.168.1.97" IsBogon="False"
+  IsProxy="False" IsTor="False" IsV4Mapped="False" IsV6="False" IsVpn="False" Language="en-GB"
+  LanguageCode="zu" Latitude="-33.925552" Longitude="18.422857"
+  Mimetypes="Portable Document Format;pdf;application/pdf|||Portable Document Format;pdf;text/pdf|||"
+  Name="South Africa Standard Time" Offset="+02:00" Os="Macintosh" Platform="MacIntel"
+  Region="Western Cape" RegionCode="WC" SrcPort="54290" Time="14:07:53.846452"
+  Upgrade-Insecure-Requests="1"
+  User-Agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+  Valid="True" Vendor="Google Inc." Version="135.0.0.0"]
+  A Web Bug Canarytoken was triggered by '192.168.1.97'.
+```
+
+Attribute description: [Canarytoken HTTP](incidents/incident-objects.html#http).
+
+#### DNS
+
+```
+  <130>1 2025-04-30T12:54:52.796337+00:00 mycompany-com ThinkstCanary 3557764 newincident
+  [BasicIncidentDetails@51136 Description="DNS Canarytoken triggered"
+  Timestamp="2025-04-30 12:52:49 (UTC)" Reminder="q" Token="vv4x12n26ivmcgyd33pkb3drr"
+  SourceIP="1.1.1.1" IncidentHash="adaa8486af78cc450417b027e2821a22" eventid="16000"]
+
+  [AdditionalIncidentDetails@51136 BackgroundContext="This alert is the first from 1.1.1.1."
+  DstPort="53" Hostname="VV4x12N26IvMcgyd33pKB3DRr[.\]123456789abe[.\]o3N[.\]Io" SrcPort="48908"]
+  A DNS Canarytoken was triggered by a DNS query from the source IP 1.1.1.1.
+  Please note that the source IP refers to a DNS resolver, rather than the host that triggered the token.
+```
+
+Attribute description: [Canarytoken DNS](incidents/incident-objects.html#dns).
+
+#### Wireguard
+
+```
+  <130>1 2025-04-30T12:56:11.569505+00:00 mycompany-com ThinkstCanary 3557764 newincident
+  [BasicIncidentDetails@51136 Description="WireGuard VPN Canarytoken triggered"
+  Timestamp="2025-04-30 12:54:09 (UTC)" Reminder="x" Token="zcowdkas4t07sedssypwiy8pi"
+  SourceIP="192.168.1.97" IncidentHash="e2888f4ae944ef9eb11f716a67602d01" eventid="17022"]
+
+  [AdditionalIncidentDetails@51136 BackgroundContext="You have had 216 incidents from 192.168.1.97 previously."
+  ClientPublicKey="xEUY2sgyvP/+3SaBY5OAS679m/LhMVQ3Ey8xDHBFKAc="
+  ClientSessionIndex="3154879465" DstPort="51820" SrcPort="57505"]
+  A WireGuard VPN Canarytoken was triggered by '192.168.1.97'.
+```
+
+Attribute description: [Canarytoken Wireguard](incidents/incident-objects.html#wireguard).
 
 ### Canary Disconnected
 
 ```log
-<130>1 2018-08-13T15:24:15.672152+00:00 mycompany-com ThinkstCanary 6051 newincident
-[BasicIncidentDetails@51136 eventid="1004" CanaryName="intranet03.mycompany.com"
-Description="Canary Disconnected" Timestamp="2018-08-13 15:24:14 (UTC)"
-IncidentHash="7e90c25b733d48fc46ce257efef497e1" CanaryLocation="Rack22 above switch"
-SourceIP="" CanaryID="0000000018a22bf1"]
+  <130>1 2018-08-13T15:24:15.672152+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="1004" CanaryName="intranet03.mycompany.com"
+  Description="Canary Disconnected" Timestamp="2018-08-13 15:24:14 (UTC)"
+  IncidentHash="7e90c25b733d48fc46ce257efef497e1" CanaryLocation="Rack22 above switch"
+  SourceIP="" CanaryID="0000000018a22bf1"]
 
-[AdditionalIncidentDetails@51136 PreviousIP="192.168.1.69"]
-One of your Canaries (intranet03.mycompany.com) previously at 192.168.1.69 has disconnected.
+  [AdditionalIncidentDetails@51136 PreviousIP="192.168.1.69"]
+  One of your Canaries (intranet03.mycompany.com) previously at 192.168.1.69 has disconnected.
 ```
-
 
 Attribute description: [Canary Disconnected](/incidents/incident-objects.html#canary-disconnected).
 
 ### Canary Reconnected
 
-
 ```
-<130>1 2018-08-13T14:12:45.238658+00:00 mycompany-com ThinkstCanary 6051 newincident
-[BasicIncidentDetails@51136 eventid="1004" CanaryName="intranet03.mycompany.com"
-Description="Canary Reconnected" Timestamp="2018-06-19 07:07:30 (UTC)"
-IncidentHash="d0e47e37d0515e2b2b0765aaaa2d584e" CanaryLocation="Rack22 above switch"
-SourceIP="" CanaryID="0000000018a22bf1"]
+  <130>1 2018-08-13T14:12:45.238658+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="1004" CanaryName="intranet03.mycompany.com"
+  Description="Canary Reconnected" Timestamp="2018-06-19 07:07:30 (UTC)"
+  IncidentHash="d0e47e37d0515e2b2b0765aaaa2d584e" CanaryLocation="Rack22 above switch"
+  SourceIP="" CanaryID="0000000018a22bf1"]
 
-
-[AdditionalIncidentDetails@51136 PreviousIP="192.168.1.69"]
-One of your Canaries (intranet03.mycompany.com) previously at 192.168.1.69 has reconnected.
+  [AdditionalIncidentDetails@51136 PreviousIP="192.168.1.69"]
+  One of your Canaries (intranet03.mycompany.com) previously at 192.168.1.69 has reconnected.
 ```
 
 ### Canary Settings Changed
 
-
 ```
-<130>1 2023-08-02T17:26:15.611322+00:00 mycompany-com ThinkstCanary 32264 newincident 
-[BasicIncidentDetails@51136 eventid="23002" CanaryName="SRV01" 
-Description="Canary Settings Changed" CanaryPort="443" Timestamp="2023-08-02 17:24:14 
-(UTC)" CanaryIP="abc123.canary.tools" IncidentHash="4f9eb17f8e470455e070a669d73a1615" 
-CanaryLocation="" SourceIP="1.1.1.1" CanaryID="00000000fc738ff7"]
+  <130>1 2023-08-02T17:26:15.611322+00:00 mycompany-com ThinkstCanary 32264 newincident
+  [BasicIncidentDetails@51136 eventid="23002" CanaryName="SRV01"
+  Description="Canary Settings Changed" CanaryPort="443" Timestamp="2023-08-02 17:24:14
+  (UTC)" CanaryIP="abc123.canary.tools" IncidentHash="4f9eb17f8e470455e070a669d73a1615"
+  CanaryLocation="" SourceIP="1.1.1.1" CanaryID="00000000fc738ff7"]
 
-[AdditionalIncidentDetails@51136 Settings="userid=admin@canary.console,ftp.enabled=True,
-telnet.enabled=True,...\x0aModified by admin@canary.console" 
-BackgroundContext="This alert is the first from 1.1.1.1."] 
-The canary 00000000fc738ff7 settings were changed by 1.1.1.1
+  [AdditionalIncidentDetails@51136 Settings="userid=admin@canary.console,ftp.enabled=True,
+  telnet.enabled=True,...\x0aModified by admin@canary.console"
+  BackgroundContext="This alert is the first from 1.1.1.1."]
+  The canary 00000000fc738ff7 settings were changed by 1.1.1.1
 ```
 
 Attribute description: [Canary Settings Changed](/incidents/incident-objects.html#canary-settings-changed).
 
 ### Console Settings Changed
 
-
 ```
-<130>1 2023-08-03T20:51:29.402623+00:00 mycompany-com ThinkstCanary 31760 newincident 
-[BasicIncidentDetails@51136 eventid="23001" CanaryName="Console" 
-Description="Console Settings Changed" Timestamp="2023-08-03 20:49:29 (UTC)" 
-CanaryIP="abc123.canary.tools" IncidentHash="88bee65ef162f7d00be81ab86ceea7e3" 
-CanaryPort="443" SourceIP="1.1.1.1" CanaryID="Console"]
+  <130>1 2023-08-03T20:51:29.402623+00:00 mycompany-com ThinkstCanary 31760 newincident
+  [BasicIncidentDetails@51136 eventid="23001" CanaryName="Console"
+  Description="Console Settings Changed" Timestamp="2023-08-03 20:49:29 (UTC)"
+  CanaryIP="abc123.canary.tools" IncidentHash="88bee65ef162f7d00be81ab86ceea7e3"
+  CanaryPort="443" SourceIP="1.1.1.1" CanaryID="Console"]
 
-[AdditionalIncidentDetails@51136 Settings="Globally Enforced 2FA Disabled: 
-New: Disabled, Old: Enabled\\x0aModification by admin@canary.console" 
-BackgroundContext="You have had 3 incidents from 1.1.1.1 previously."] 
-The console settings were changed by 1.1.1.1
+  [AdditionalIncidentDetails@51136 Settings="Globally Enforced 2FA Disabled:
+  New: Disabled, Old: Enabled\\x0aModification by admin@canary.console"
+  BackgroundContext="You have had 3 incidents from 1.1.1.1 previously."]
+  The console settings were changed by 1.1.1.1
 ```
 
 Attribute description: [Console Settings Changed](/incidents/incident-objects.html#console-settings-changed).
+
+### Flock Settings Changed
+
+```
+  <130>1 2025-04-30T22:42:19.845759+00:00 mycompany-com ThinkstCanary 3602455 newincident
+  [BasicIncidentDetails@51136
+  Description="Flock Settings Changed" Timestamp="2025-04-30 22:40:17 (UTC)"
+  CanaryName="Flock" CanaryID="flock_change" CanaryIP="abc123.canary.tools"
+  SourceIP="196.61.107.19" CanaryPort="443"
+  IncidentHash="7a3b1b7b0cd1889d2c0f1e625926dde2" eventid="23003"]
+  [AdditionalIncidentDetails@51136
+  Settings="enable_emails_notifications=True\\x0aModified by user"
+  BackgroundContext="You have had 217 incidents from 196.61.107.19 previously."]
+  The flock Default Flock settings were changed by 196.61.107.19
+```
+
+Attribute description: [Flock Settings Changed](/incidents/incident-objects.html#flock-settings-changed).
 
 ### Consolidated Network Port Scan
 
@@ -175,7 +246,6 @@ Attribute description: [Console Settings Changed](/incidents/incident-objects.ht
   [AdditionalIncidentDetails@51136 Source="192.168.1.82"
   Incident="Consolidated Network Port Scan" Targets="192.168.1.29, 192.168.1.69"]
   A portscan has been done on several of your canaries by the host 192.168.1.82.
-
 ```
 
 Attribute description: [Consolidated Network Port Scan](/incidents/incident-objects.html#consolidated-network-port-scan).
@@ -200,15 +270,14 @@ Attribute description: [Custom TCP Service Request](/incidents/incident-objects.
 ### Dummy Incident
 
 ```
-
   <130>1 2023-08-02T17:02:11.371589+00:00 mycompany-com ThinkstCanary 32264 newincident
-  [BasicIncidentDetails@51136 eventid="111111" ReverseDNS="attacker-ip.local" 
-  CanaryName="VirtualCanary-unnamed" Description="Dummy Incident" CanaryPort="8080" 
-  Timestamp="2023-08-02 17:02:11 (UTC)" CanaryIP="1.1.1.1" 
-  IncidentHash="aa875f255f94e3ffe40dc85cf1a8b1e0" CanaryLocation="Server room A" 
+  [BasicIncidentDetails@51136 eventid="111111" ReverseDNS="attacker-ip.local"
+  CanaryName="VirtualCanary-unnamed" Description="Dummy Incident" CanaryPort="8080"
+  Timestamp="2023-08-02 17:02:11 (UTC)" CanaryIP="1.1.1.1"
+  IncidentHash="aa875f255f94e3ffe40dc85cf1a8b1e0" CanaryLocation="Server room A"
   SourceIP="2.2.2.2" CanaryID="000246ec65ef9476"]
 
-  [AdditionalIncidentDetails@51136 Field2="VALUE2" Field3="VALUE3" Field1="VALUE1"] 
+  [AdditionalIncidentDetails@51136 Field2="VALUE2" Field3="VALUE3" Field1="VALUE1"]
   This is a fake intro.
 ```
 
@@ -232,7 +301,6 @@ Attribute description: [Dummy Incident](/incidents/incident-objects.html#dummy-i
 ```
 
 Attribute description: [FTP Login Attempt](/incidents/incident-objects.html#ftp-login-attempt).
-
 
 ### Git Repository Clone Attempt
 
@@ -268,25 +336,28 @@ Attribute description: [Git Repository Clone Attempt](/incidents/incident-object
 
 Attribute description: [Host Port Scan](/incidents/incident-objects.html#host-port-scan).
 
-### HTTP API Request
+### HTTP Incidents
+
+#### HTTP API Request
 
 ```
-  <130>1 2023-08-03T19:39:17.338417+00:00 mycompany-com ThinkstCanary 31760 newincident 
-  [BasicIncidentDetails@51136 eventid="3005" ReverseDNS="" CanaryName="SRV01" 
-  Description="HTTP API Request" CanaryPort="80" Timestamp="2023-08-03 19:37:17 (UTC)" 
-  CanaryIP="192.168.1.104" IncidentHash="afbd5fdee00c4169a3297fdd9b5b368a" CanaryLocation="" 
+  <130>1 2023-08-03T19:39:17.338417+00:00 mycompany-com ThinkstCanary 31760 newincident
+
+  [BasicIncidentDetails@51136 eventid="3005" ReverseDNS="" CanaryName="SRV01"
+  Description="HTTP API Request" CanaryPort="80" Timestamp="2023-08-03 19:37:17 (UTC)"
+  CanaryIP="192.168.1.104" IncidentHash="afbd5fdee00c4169a3297fdd9b5b368a" CanaryLocation=""
   SourceIP="1.1.1.1" CanaryID="00000000fc738ff7"]
 
-  [AdditionalIncidentDetails@51136 Path="/api/v1/post-test" User-Agent="curl/8.1.2" 
-  Headers="{'host': '192.168.1.104', 'content-type': 'application/x-www-form-urlencoded', 
+  [AdditionalIncidentDetails@51136 Path="/api/v1/post-test" User-Agent="curl/8.1.2"
+  Headers="{'host': '192.168.1.104', 'content-type': 'application/x-www-form-urlencoded',
   'content-length': '11', 'accept': '*/*'}"
-  BackgroundContext="You have had 115 incidents from 1.1.1.1 previously."] 
+  BackgroundContext="You have had 115 incidents from 1.1.1.1 previously."]
   HTTP API Request has been detected against one of your Canaries (SRV01) at 192.168.1.104.
 ```
 
 Attribute description: [HTTP API Request](/incidents/incident-objects.html#http-api-request).
 
-### HTTP login
+#### HTTP Login Attempt
 
 ```
   <130>1 2018-08-13T13:22:07.159097+00:00 mycompany-com ThinkstCanary 6051 newincident
@@ -303,7 +374,64 @@ Attribute description: [HTTP API Request](/incidents/incident-objects.html#http-
 
 Attribute description: [HTTP Login Attempt](/incidents/incident-objects.html#http-login-attempt).
 
-### HTTP Proxy Request
+#### HTTP Page Load
+
+```
+  <130>1 2025-04-30T13:43:32.453578+00:00 mycompany-com ThinkstCanary 3557748 newincident
+  [BasicIncidentDetails@51136 Description="HTTP Page Load"
+  Timestamp="2025-04-30 13:41:31 (UTC)" CanaryName="intranet03.mycompany.com"
+  CanaryID="0000000018a22bf1" CanaryIP="192.168.1.69" CanaryPublicIP="3.4.5.6"
+  SourceIP="172.31.6.248" CanaryLocation="VPC vpc-0ddb2a123456789ab" ReverseDNS=""
+  CanaryPort="80" IncidentHash="e254a07fb49885f5cdde47731d3602d0" eventid="3000"]
+
+  [AdditionalIncidentDetails@51136 Path="/" User-Agent="python-requests/2.31.0"
+  Headers="{'connection': 'keep-alive', 'host': '192.168.1.69', 'accept': '*/*', 'accept-encoding': 'gzip, deflate'}"
+  BackgroundContext="You have had 163 incidents from 172.31.6.248 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  HTTP Page Load has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [HTTP Page Load](/incidents/incident-objects.html#http-page-load).
+
+#### HTTP Post Error
+
+```
+  <130>1 2025-04-30T14:38:14.359286+00:00 mycompany-com ThinkstCanary 3557748 newincident
+  [BasicIncidentDetails@51136 Description="HTTP Login Attempt"
+  Timestamp="2025-04-30 14:36:13 (UTC)" CanaryName="intranet03.mycompany.com"
+  CanaryID="0000000018a22bf1" CanaryIP="192.168.1.69" CanaryPublicIP="3.4.5.6"
+  SourceIP="34.248.192.232" CanaryLocation="VPC vpc-0ddb2a123456789ab"
+  ReverseDNS="attacker.in.mycompany.com" CanaryPort="80"
+  IncidentHash="d9b1815e21d80fb240ca9b2d17120ad1" eventid="3006"]
+
+  [AdditionalIncidentDetails@51136 User-Agent="python-requests/2.31.0"
+  Headers="{'host': '3.4.5.6', 'connection': 'keep-alive', 'content-length': '0', 'accept-encoding': 'gzip, deflate', 'accept': '*/*'}"
+  BackgroundContext="You have had 176 incidents from 34.248.192.232 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  HTTP Login Attempt has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [HTTP Post Error](/incidents/incident-objects.html#http-post-error-page).
+
+#### HTTP Service Scan
+
+```
+  <130>1 2025-04-30T14:07:02.183648+00:00 mycompany-com ThinkstCanary 3557748 newincident
+  [BasicIncidentDetails@51136 Description="Website Scan"
+  Timestamp="2025-04-30 14:05:01 (UTC)" CanaryName="intranet03.mycompany.com"
+  CanaryID="0000000018a22bf1" CanaryIP="192.168.1.69" CanaryPublicIP="3.4.5.6"
+  SourceIP="172.31.6.248" CanaryLocation="VPC vpc-0ddb2a123456789ab" ReverseDNS=""
+  CanaryPort="80" IncidentHash="65693b99a976d66ae8e1d68cfd05d33e" eventid="3004"]
+
+  [AdditionalIncidentDetails@51136 Path="/b0669"
+  BackgroundContext="You have had 231 incidents from 172.31.6.248 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  Website Scan has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [HTTP Service Scan](/incidents/incident-objects.html#http-service-scan).
+
+#### HTTP Proxy Request
 
 ```
   <130>1 2018-08-13T13:22:41.146736+00:00 mycompany-com ThinkstCanary 6051 newincident
@@ -316,7 +444,6 @@ Attribute description: [HTTP Login Attempt](/incidents/incident-objects.html#htt
   [AdditionalIncidentDetails@51136 Username="proxy" URL="http://google.com/" Password="proxypass"
   User-Agent="curl/7.54.0"] HTTP Proxy Request has been detected against one of your Canaries
   (intranet03.mycompany.com) at 192.168.1.69.
-
 ```
 
 Attribute description: [HTTP Proxy Request](/incidents/incident-objects.html#http-proxy-request).
@@ -324,16 +451,15 @@ Attribute description: [HTTP Proxy Request](/incidents/incident-objects.html#htt
 ### Local Tampering Detected
 
 ```
-
-  <130>1 2023-08-03T20:22:38.421418+00:00 mycompany-com ThinkstCanary 13487 newincident 
-  [BasicIncidentDetails@51136 eventid="30001" ReverseDNS="" CanaryName="SRV01-12345" 
-  Description="Local Tampering Detected" CanaryPort="-1" 
-  Timestamp="2023-08-03 20:20:38 (UTC)" CanaryIP="192.168.5.200" Flock="Renoster 3.x.5" 
-  CanaryLocation="" SourceIP="" IncidentHash="8d64f579666fe2029b12c87baa6dec41" 
+  <130>1 2023-08-03T20:22:38.421418+00:00 mycompany-com ThinkstCanary 13487 newincident
+  [BasicIncidentDetails@51136 eventid="30001" ReverseDNS="" CanaryName="SRV01-12345"
+  Description="Local Tampering Detected" CanaryPort="-1"
+  Timestamp="2023-08-03 20:20:38 (UTC)" CanaryIP="192.168.5.200" Flock="Renoster 3.x.5"
+  CanaryLocation="" SourceIP="" IncidentHash="8d64f579666fe2029b12c87baa6dec41"
   CanaryID="0000000005bb4998"]
-  
-  [AdditionalIncidentDetails@51136 Incident="Local Tampering Detected" 
-  Message="A local user on your bird (uid 0) ran tripwired commands: /usr/bin/curl,http://google.com"] 
+
+  [AdditionalIncidentDetails@51136 Incident="Local Tampering Detected"
+  Message="A local user on your bird (uid 0) ran tripwired commands: /usr/bin/curl,http://google.com"]
   Local Tampering Detected has been detected against one of your Canaries (SRV01-12345) at 192.168.5.200.
 ```
 
@@ -342,18 +468,16 @@ Attribute description: [Local Tampering Detected](/incidents/incident-objects.ht
 ### LDAP Bind Attempt
 
 ```
-
-  <130>1 2023-08-02T17:41:44.856428+00:00 mycompany-com ThinkstCanary 32264 newincident 
-  [BasicIncidentDetails@51136 eventid="31001" ReverseDNS="" CanaryName="SRV01" 
-  Description="LDAP Bind Attempt Detected" CanaryPort="389" 
-  Timestamp="2023-08-02 17:39:44 (UTC)" CanaryIP="192.168.1.104" 
-  IncidentHash="e1d3afbbfe6ac5c5a4da497df92da3e0" CanaryLocation="" SourceIP="1.1.1.1" 
+  <130>1 2023-08-02T17:41:44.856428+00:00 mycompany-com ThinkstCanary 32264 newincident
+  [BasicIncidentDetails@51136 eventid="31001" ReverseDNS="" CanaryName="SRV01"
+  Description="LDAP Bind Attempt Detected" CanaryPort="389"
+  Timestamp="2023-08-02 17:39:44 (UTC)" CanaryIP="192.168.1.104"
+  IncidentHash="e1d3afbbfe6ac5c5a4da497df92da3e0" CanaryLocation="" SourceIP="1.1.1.1"
   CanaryID="00000000fc738ff7"]
 
-
-  [AdditionalIncidentDetails@51136 DistinguishedName="cn=testuser" 
-  Request="bindRequest" Password="pass" 
-  BackgroundContext="You have had 111 incidents from 1.1.1.1 previously."] 
+  [AdditionalIncidentDetails@51136 DistinguishedName="cn=testuser"
+  Request="bindRequest" Password="pass"
+  BackgroundContext="You have had 111 incidents from 1.1.1.1 previously."]
   LDAP Bind Attempt Detected has been detected against one of your Canaries (SRV01) at 192.168.1.104.
 ```
 
@@ -362,13 +486,48 @@ Attribute description: [LDAP Bind Attempt](/incidents/incident-objects.html#ldap
 ### MARK Message
 
 ```
-  <130>syslog	info	rsyslogd	-- MARK -- 
+  <130>syslog	info	rsyslogd	-- MARK --
 ```
 
-### Microsoft SQL Server Login
+### ModBus Request
 
 ```
+  <130>1 2018-08-13T13:34:28.905941+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="18001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="ModBus Request" CanaryPort="502"
+  Timestamp="2018-08-13 13:34:28 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="dfc7b90a4d88315281b76283766e347b" CanaryLocation="Rack22 above switch"
+  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
 
+  [AdditionalIncidentDetails@51136 Functioncode="17" Functionname="Report Slave ID"]
+  ModBus Request has been detected against one of your Canaries
+  (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [ModBus Request](/incidents/incident-objects.html#modbus-request).
+
+### Mongo Request
+
+```
+  <130>1 2025-04-30T13:28:43.263119+00:00 mycompany-com ThinkstCanary 3557748 newincident
+  [BasicIncidentDetails@51136 Description="Mongo Authentication Attempt"
+  Timestamp="2025-04-30 13:26:42 (UTC)" CanaryName="intranet03.mycompany.com"
+  CanaryID="0000000018a22bf1" CanaryIP="192.168.1.69" CanaryPublicIP="3.4.5.6"
+  SourceIP="172.31.6.248" CanaryLocation="VPC vpc-0ddb2a123456789ab" ReverseDNS=""
+  CanaryPort="27017" IncidentHash="3ba686459d3e3319ab877fb3bbf31fa3" eventid="28002"]
+
+  [AdditionalIncidentDetails@51136 User="mongo1"
+  PasswordHash="353GBkv67L1bpgt3PQUEr4536qRn4NR6" Command="saslStart" Database="admin"
+  BackgroundContext="You have had 135 incidents from 172.31.6.248 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  Mongo Authentication Attempt has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [Mongo Request](/incidents/incident-objects.html#mongo-request).
+
+### MSSQL Server Login Attempt
+
+```
   <130>1 2018-08-13T13:50:28.649855+00:00 mycompany-com ThinkstCanary 6051 newincident
   [BasicIncidentDetails@51136 eventid="9001" ReverseDNS="attacker.in.mycompany.com"
   CanaryName="intranet03.mycompany.com" Description="MSSQL Login Attempt" CanaryPort="1433"
@@ -384,25 +543,7 @@ Attribute description: [LDAP Bind Attempt](/incidents/incident-objects.html#ldap
 
 Attribute description: [MSSQL Login Attempt](/incidents/incident-objects.html#mssql-login-attempt).
 
-### ModBus Request
-
-```
-  <130>1 2018-08-13T13:34:28.905941+00:00 mycompany-com ThinkstCanary 6051 newincident
-  [BasicIncidentDetails@51136 eventid="18001" ReverseDNS="attacker.in.mycompany.com"
-  CanaryName="intranet03.mycompany.com" Description="ModBus Request" CanaryPort="502"
-  Timestamp="2018-08-13 13:34:28 (UTC)" CanaryIP="192.168.1.69"
-  IncidentHash="dfc7b90a4d88315281b76283766e347b" CanaryLocation="Rack22 above switch"
-  SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
-
-  [AdditionalIncidentDetails@51136 Functioncode="17" Functionname="Report Slave ID"]
-  ModBus Request has been detected against one of your Canaries
-  (intranet03.mycompany.com) at 192.168.1.69.
-
-```
-
-Attribute description: [ModBus Request](/incidents/incident-objects.html#modbus-request).
-
-### MySQL Login
+### MySQL Login Attempt
 
 ```
   <130>1 2018-08-13T13:35:33.585011+00:00 mycompany-com ThinkstCanary 6051 newincident
@@ -422,6 +563,23 @@ Attribute description: [ModBus Request](/incidents/incident-objects.html#modbus-
 
 Attribute description: [MySQL Login Attempt](/incidents/incident-objects.html#mysql-login-attempt).
 
+### Network Settings Roll-back
+
+```
+  <130>1 2025-04-30T15:26:32.393844+00:00 mycompany-com ThinkstCanary 3602455 newincident
+  [BasicIncidentDetails@51136 Description="Network Settings Roll-back"
+  Timestamp="2025-04-30 15:24:31 (UTC)" CanaryName="SRV-SMB-AFTER"
+  CanaryID="00000000c2249f3b" CanaryIP="192.168.1.206" CanaryLocation=""
+  IncidentHash="e296e8f097cd7fd18810a03d8fcc85c0" eventid="22001"]
+
+  [AdditionalIncidentDetails@51136 CanaryStatus="Canary is currently ONLINE."
+  Erroneousnetworksettings="Canary IP address: 192.168.1.206; Netmask: 255.255.255.0; Gateway: 192.168.1.1; DNS server 1: 8.7.6.5; DNS server 2: 8.7.6.5; DHCP: Disabled"
+  Restorednetworksettings="Canary IP address: 192.168.1.206; DHCP: Enabled"
+  User="user"]
+  Network Settings Roll-back has been detected against one of your Canaries (SRV-SMB-AFTER).
+```
+
+Attribute description: [Network Settings Roll-back](/incidents/incident-objects.html#network-settings-roll-back)
 
 ### Nmap NULL Scan
 
@@ -473,7 +631,6 @@ Attribute description: [NMAP OS Scan](/incidents/incident-objects.html#nmap-os-s
 
 ### Nmap Xmas Scan
 
-
 ```
 
   <130>1 2018-08-13T13:32:46.469290+00:00 mycompany-com ThinkstCanary 6051 newincident
@@ -505,6 +662,24 @@ Attribute description: [NMAP XMAS Scan](/incidents/incident-objects.html#nmap-xm
 ```
 
 Attribute description: [NTP Monlist Request](/incidents/incident-objects.html#ntp-monlist-request).
+
+### RDP Login Attempt
+
+```
+  <130>1 2025-04-30T13:30:31.803745+00:00 mycompany-com ThinkstCanary 3557748 newincident
+  [BasicIncidentDetails@51136 Description="RDP Login Attempt"
+  Timestamp="2025-04-30 13:28:30 (UTC)" CanaryName="intranet03.mycompany.com"
+  CanaryID="0000000018a22bf1" CanaryIP="192.168.1.69" CanaryPublicIP="3.4.5.6"
+  SourceIP="172.31.6.248" CanaryLocation="VPC vpc-0ddb2a123456789ab" ReverseDNS=""
+  CanaryPort="3389" IncidentHash="eb607ac4c94cf5103189f1e38fba6228" eventid="14003"]
+
+  [AdditionalIncidentDetails@51136
+  BackgroundContext="You have had 137 incidents from 172.31.6.248 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  RDP Login Attempt has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [RDP Login Attempt](/incidents/incident-objects.html#rdp-login-attempt).
 
 ### Redis Command
 
@@ -547,7 +722,7 @@ Attribute description: [Redis Command](/incidents/incident-objects.html#redis-co
 
 Attribute description: [SIP Request](/incidents/incident-objects.html#sip-request).
 
-### SNMP
+### SNMP Request
 
 ```
   <130>1 2018-08-13T13:21:23.127789+00:00 mycompany-com ThinkstCanary 6051 newincident
@@ -564,8 +739,7 @@ Attribute description: [SIP Request](/incidents/incident-objects.html#sip-reques
 
 Attribute description: [SNMP Request](/incidents/incident-objects.html#snmp-request).
 
-
-### SSH (Password login)
+### SSH Login Attempt (Password)
 
 ```
   <130>1 2018-08-13T14:23:07.413167+00:00 mycompany-com ThinkstCanary 6051 newincident
@@ -582,7 +756,7 @@ Attribute description: [SNMP Request](/incidents/incident-objects.html#snmp-requ
 
 Attribute description: [SSH Login Attempt](/incidents/incident-objects.html#ssh-login-attempt).
 
-### SSH (key-based login)
+### SSH Login Attempt(key-based)
 
 ```
   <130>1 2018-08-13T14:16:01.152948+00:00 mycompany-com ThinkstCanary 6051 newincident
@@ -602,7 +776,6 @@ Attribute description: [SSH Login Attempt](/incidents/incident-objects.html#ssh-
 
 ### Telnet Login Attempt
 
-
 ```
   <130>1 2018-08-13T13:19:51.015053+00:00 mycompany-com ThinkstCanary 6051 newincident
   [BasicIncidentDetails@51136 eventid="6001" ReverseDNS="attacker.in.mycompany.com"
@@ -620,21 +793,37 @@ Attribute description: [Telnet Login Attempt](/incidents/incident-objects.html#t
 
 ### TFTP Request
 
-
 ```
-  <130>1 2018-08-13T13:25:37.021004+00:00 mycompany-com ThinkstCanary 6051 newincident 
-  [BasicIncidentDetails@51136 eventid="10001" ReverseDNS="attacker.in.mycompany.com" 
-  CanaryName="intranet03.mycompany.com" Description="TFTP Request" CanaryPort="69" 
-  Timestamp="2018-08-13 13:25:36 (UTC)" CanaryIP="192.168.1.69" 
-  IncidentHash="6e79bb7c281780a5130c1a54b64759a0" CanaryLocation="Rack22 above switch" 
+  <130>1 2018-08-13T13:25:37.021004+00:00 mycompany-com ThinkstCanary 6051 newincident
+  [BasicIncidentDetails@51136 eventid="10001" ReverseDNS="attacker.in.mycompany.com"
+  CanaryName="intranet03.mycompany.com" Description="TFTP Request" CanaryPort="69"
+  Timestamp="2018-08-13 13:25:36 (UTC)" CanaryIP="192.168.1.69"
+  IncidentHash="6e79bb7c281780a5130c1a54b64759a0" CanaryLocation="Rack22 above switch"
   SourceIP="192.168.1.82" CanaryID="0000000018a22bf1"]
-  
-  [AdditionalIncidentDetails@51136 Action="READ" Filename="/etc/passwd"] 
-  TFTP Request has been detected against one of your Canaries (intranet03.mycompany.com) 
+
+  [AdditionalIncidentDetails@51136 Action="READ" Filename="/etc/passwd"]
+  TFTP Request has been detected against one of your Canaries (intranet03.mycompany.com)
   at 192.168.1.69.
 ```
 
 Attribute description: [TFTP Request](/incidents/incident-objects.html#tftp-request).
+
+### TN3270 Login Attempt
+
+```
+  <130>1 2025-04-30T15:10:30.912872+00:00 mycompany-com ThinkstCanary 3602455 newincident
+  [BasicIncidentDetails@51136 Description="TN3270 Login Attempt" Timestamp="2025-04-30 15:08:29 (UTC)"
+  CanaryName="intranet03.mycompany.com" CanaryID="0000000018a22bf1" CanaryIP="192.168.1.69"
+  CanaryPublicIP="3.4.5.6" SourceIP="172.31.6.248" CanaryLocation="VPC vpc-0ddb2a123456789ab"
+  ReverseDNS="" CanaryPort="1023" IncidentHash="9410561b83074787818463a41a54e1c6" eventid="32001"]
+
+  [AdditionalIncidentDetails@51136 Username="USER100" Password="passwd1"
+  BackgroundContext="You have had 248 incidents from 172.31.6.248 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  TN3270 Login Attempt has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+Attribute description: [TN3270 Login](/incidents/incident-objects.html#tn3270-login).
 
 ### VNC Login Attempt
 
@@ -654,7 +843,11 @@ Attribute description: [TFTP Request](/incidents/incident-objects.html#tftp-requ
 
 Attribute description: [VNC Login Attempt](/incidents/incident-objects.html#vnc-login-attempt).
 
-### Shared File Opened
+### Windows File Share Incidents
+
+Attribute description: [Windows File Share Incidents](/incidents/incident-objects.html#windows-file-share-incidents).
+
+#### Windows Shared File Opened
 
 ```
   <130>1 2018-08-13T13:56:39.819028+00:00 mycompany-com ThinkstCanary 6051 newincident
@@ -669,8 +862,69 @@ Attribute description: [VNC Login Attempt](/incidents/incident-objects.html#vnc-
   (intranet02.mycompany.com) at 192.168.1.29.
 ```
 
-Attribute description: [Shared File Opened](/incidents/incident-objects.html#shared-file-opened).
+#### Windows File Share Login Incident
 
+```
+  <130>1 2025-04-30T13:53:03.465190+00:00 mycompany-com ThinkstCanary 3557748 newincident
+  [BasicIncidentDetails@51136 Description="File Share Login" Timestamp="2025-04-30 13:51:02 (UTC)"
+  CanaryName="intranet03.mycompany.com" CanaryID="0000000018a22bf1" CanaryIP=""
+  CanaryPublicIP="3.4.5.6" SourceIP="172.31.6.248" CanaryLocation="VPC vpc-0ddb2a123456789ab"
+  ReverseDNS="" CanaryPort="445" IncidentHash="a7480e533297c63713ded75eaa23dd1a" eventid="5010"]
 
+  [AdditionalIncidentDetails@51136 LoginType="guest" Success="True" User="guest"
+  RemoteSMBName="nmap" Domain="AWS-NEW-I-0ABCD"
+  BackgroundContext="You have had 173 incidents from 172.31.6.248 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  File Share Login has been detected against one of your Canaries (intranet03.mycompany.com) at .
+```
 
+#### Windows File Share Enumeration Incident
 
+```
+  <130>1 2025-04-30T15:05:25.607807+00:00 mycompany-com ThinkstCanary 3602455 newincident
+  [BasicIncidentDetails@51136 Description="File Share Group Enumeration"
+  Timestamp="2025-04-30 15:03:24 (UTC)" CanaryName="intranet03.mycompany.com"
+  CanaryID="0000000018a22bf1" CanaryIP="" CanaryPublicIP="3.4.5.6" SourceIP="172.31.6.128"
+  CanaryLocation="VPC vpc-0ddb2a123456789ab" ReverseDNS="" CanaryPort="445"
+  IncidentHash="d16786119d7e88da67ac76b54a17cd5d" eventid="5013"]
+
+  [AdditionalIncidentDetails@51136 User="Administrator" ShareName="IPC$" Domain="CORP"
+  Success="success" WindowsAPIQueried="NetLocalGroup"
+  BackgroundContext="You have had 2 incidents from 172.31.6.128 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  File Share Group Enumeration has been detected against one of your Canaries (intranet03.mycompany.com) at .
+```
+
+#### Windows File Share Connected Incident
+
+```
+  <130>1 2025-04-30T13:53:04.553584+00:00 mycompany-com ThinkstCanary 3557748 newincident
+  [BasicIncidentDetails@51136 Description="File Share Connection"
+  Timestamp="2025-04-30 13:51:03 (UTC)" CanaryName="intranet03.mycompany.com"
+  CanaryID="0000000018a22bf1" CanaryIP="192.168.1.69" CanaryPublicIP="3.4.5.6"
+  SourceIP="172.31.6.248" CanaryLocation="VPC vpc-0ddb2a123456789ab" ReverseDNS=""
+  CanaryPort="445" IncidentHash="b25a7ebe9a2d4ff5c5ac531cb739728b" eventid="5014"]
+
+  [AdditionalIncidentDetails@51136 User="guest" ShareName="ADMIN$"
+  Domain="AWS-NEW-I-0ABCD" RemoteSMBName="nmap" SMBVersion="NT1"
+  BackgroundContext="You have had 173 incidents from 172.31.6.248 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  File Share Connection has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+
+### WinRM Login Attempt
+
+```
+  <130>1 2025-04-30T15:15:58.979526+00:00 mycompany-com ThinkstCanary 3602455 newincident
+  [BasicIncidentDetails@51136 Description="WinRM Login Attempt"
+  Timestamp="2025-04-30 15:13:57 (UTC)" CanaryName="intranet03.mycompany.com"
+  CanaryID="0000000018a22bf1" CanaryIP="192.168.1.69" CanaryPublicIP="3.4.5.6"
+  SourceIP="172.31.6.248" CanaryLocation="VPC vpc-0ddb2a123456789ab" ReverseDNS=""
+  CanaryPort="5986" IncidentHash="b9cb8a238f907e27c24132500296ba26" eventid="29001"]
+
+  [AdditionalIncidentDetails@51136 Username="adam" Domain="corp"
+  BackgroundContext="You have had 249 incidents from 172.31.6.248 previously."
+  EC2InstanceID="i-0abcd9876543210ef" EC2Region="eu-west-1a"]
+  WinRM Login Attempt has been detected against one of your Canaries (intranet03.mycompany.com) at 192.168.1.69.
+```
+Attribute description: [WinRM Login Attempt](/incidents/incident-objects.html#winrm-login-attempt).

--- a/docs/syslog/rfc5424.md
+++ b/docs/syslog/rfc5424.md
@@ -120,7 +120,7 @@ Here we provide example Syslog entries that might be sent, in RFC5424 format. Ea
   A Web Bug Canarytoken was triggered by '192.168.1.97'.
 ```
 
-Attribute description: [Canarytoken HTTP](incidents/incident-objects.html#http).
+Attribute description: [Canarytoken HTTP](/incidents/incident-objects.html#http).
 
 #### DNS
 
@@ -136,7 +136,7 @@ Attribute description: [Canarytoken HTTP](incidents/incident-objects.html#http).
   Please note that the source IP refers to a DNS resolver, rather than the host that triggered the token.
 ```
 
-Attribute description: [Canarytoken DNS](incidents/incident-objects.html#dns).
+Attribute description: [Canarytoken DNS](/incidents/incident-objects.html#dns).
 
 #### Wireguard
 
@@ -152,7 +152,7 @@ Attribute description: [Canarytoken DNS](incidents/incident-objects.html#dns).
   A WireGuard VPN Canarytoken was triggered by '192.168.1.97'.
 ```
 
-Attribute description: [Canarytoken Wireguard](incidents/incident-objects.html#wireguard).
+Attribute description: [Canarytoken Wireguard](/incidents/incident-objects.html#wireguard).
 
 ### Canary Disconnected
 


### PR DESCRIPTION
## Proposed changes

Some notification objects aren't present in the rfc5424 docs page. Since that data format has its own structure, we need to include samples of each of those objects in this page too.

## Types of changes
- [x] Documentation Update

## Checklist
- [x] I have added necessary documentation (if appropriate)