### PR TITLE
Correct summary email documentation

### DIFF
--- a/docs/console-settings/notification-settings.md
+++ b/docs/console-settings/notification-settings.md
@@ -427,9 +427,13 @@ print(r.json())
 
 ## Summary Emails
 
-If you want, we can send you a weekly summary of your Console activity. Along with that, we'll include any Canary related news that we deem useful (this usually includes a couple of worthy news items).
+If you want, we can send a weekly summary of your Console activity every Monday. Along with that, we'll include any Canary related news that we deem useful (this usually includes a couple of worthy news items).
 
-Simply [enable](#enable-summary-emails) and [set a list of email addresses](#set-summary-emails) and look out for the weekly mail every Monday!
+The endpoints on this page are for configuring summary email delivery to email addresses that are not registered Console users.
+
+To enable or disable summary emails for a registered Console user, use the `/api/v1/user/summary_email/enable` and `/api/v1/user/summary_email/disable` endpoints documented on the [Users Management](../users/management.md#enable-user-summary-email) page.
+
+To configure summary emails for non-user recipient addresses, [enable](#enable-summary-emails) summary emails and [set a list of email addresses](#set-summary-emails).
 
 ### Disable Summary Emails
 

--- a/docs/console-settings/notification-settings.md
+++ b/docs/console-settings/notification-settings.md
@@ -429,7 +429,7 @@ print(r.json())
 
 If you want, we can send you a weekly summary of your Console activity. Along with that, we'll include any Canary related news that we deem useful (this usually includes a couple of worthy news items).
 
-Simply [enable](#enable-summary-emails) and [set a list of email addresses](#set-summary-emails) and look out for the weekly mail on Mondays!
+Simply [enable](#enable-summary-emails) and [set a list of email addresses](#set-summary-emails) and look out for the weekly mail every Monday!
 
 ### Disable Summary Emails
 

--- a/docs/users/management.md
+++ b/docs/users/management.md
@@ -264,7 +264,7 @@ endpoints:
     name: Disable User Summary Email
     url: /api/v1/user/summary_email/disable
     method: POST
-    description: Disables summary email notifications for a specified user. Admins may disable summary emails for any user, but regular users may only disable summary emails for themselves
+    description: Disables summary email notifications for a specified user.
     params:
       - name: auth_token
         required: true
@@ -279,7 +279,7 @@ endpoints:
     name: Enable User Summary Email
     url: /api/v1/user/summary_email/enable
     method: POST
-    description: Enables summary email notifications for a specified user. Admins may enable summary emails for any user, but regular users may only enable summary emails for themselves.
+    description: Enables summary email notifications for a specified user.
     params:
       - name: auth_token
         required: true

--- a/docs/users/management.md
+++ b/docs/users/management.md
@@ -120,6 +120,21 @@ endpoints:
         type: string
         description: The email address of the user to be enabled
     response: JSON structure with result indicator.
+  enable_user_summary_email:
+    name: Enable User Summary Email
+    url: /api/v1/user/summary_email/enable
+    method: POST
+    description: Enables summary email notifications for a specified user. Admins may enable summary emails for any user, but regular users may only enable summary emails for themselves.
+    params:
+      - name: auth_token
+        required: true
+        type: string
+        description: A valid auth token
+      - name: email
+        required: true
+        type: string
+        description: The email address of the user whose summary emails should be enabled
+    response: JSON structure with result indicator.
   disable_user_2fa:
     name: Disable User's TOTP
     url: /api/v1/user/2fa/disable
@@ -259,6 +274,21 @@ endpoints:
         required: true
         type: string
         description: The email address of the user to be removed
+    response: JSON structure with result indicator.
+  disable_user_summary_email:
+    name: Disable User Summary Email
+    url: /api/v1/user/summary_email/disable
+    method: POST
+    description: Disables summary email notifications for a specified user. Admins may disable summary emails for any user, but regular users may only disable summary emails for themselves
+    params:
+      - name: auth_token
+        required: true
+        type: string
+        description: A valid auth token
+      - name: email
+        required: true
+        type: string
+        description: The email address of the user whose summary emails should be disabled
     response: JSON structure with result indicator.
 ---
 
@@ -704,6 +734,62 @@ print(r.json())
 
 </APIDetails>
 
+## Disable User Summary Email
+
+::: tip
+Users can disable summary emails for themselves. Disabling summary emails for another user requires a global admin account.
+:::
+
+<APIDetails :endpoint="$page.frontmatter.endpoints.disable_user_summary_email">
+
+::::: slot example
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "cURL"
+
+``` bash
+curl https://EXAMPLE.canary.tools/api/v1/user/summary_email/disable \
+  -d auth_token=EXAMPLE_AUTH_TOKEN \
+  -d email=EXAMPLE_USER_EMAIL
+```
+
+:::
+
+::: tab "Python"
+
+``` python
+import requests
+
+url = 'https://EXAMPLE.canary.tools/api/v1/user/summary_email/disable'
+
+payload = {
+  'auth_token': 'EXAMPLE_AUTH_TOKEN',
+  'email': 'EXAMPLE_USER_EMAIL'
+}
+
+r = requests.post(url, data=payload)
+
+print(r.json())
+```
+
+:::
+
+::::
+
+::: api-response
+```json
+{
+  "msg": "Successfully disabled summary email for email <user_email>",
+  "result": "success"
+}
+```
+:::
+
+:::::
+
+</APIDetails>
+
 ## Edit User
 
 <APIDetails :endpoint="$page.frontmatter.endpoints.edit_user">
@@ -854,6 +940,62 @@ print(r.json())
 ```json
 {
   "msg": "User (<user_email>) successfully enabled.",
+  "result": "success"
+}
+```
+:::
+
+:::::
+
+</APIDetails>
+
+## Enable User Summary Email
+
+::: tip
+Users can enable summary emails for themselves. Enabling summary emails for another user requires a global admin account.
+:::
+
+<APIDetails :endpoint="$page.frontmatter.endpoints.enable_user_summary_email">
+
+::::: slot example
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "cURL"
+
+``` bash
+curl https://EXAMPLE.canary.tools/api/v1/user/summary_email/enable \
+  -d auth_token=EXAMPLE_AUTH_TOKEN \
+  -d email=EXAMPLE_USER_EMAIL
+```
+
+:::
+
+::: tab "Python"
+
+``` python
+import requests
+
+url = 'https://EXAMPLE.canary.tools/api/v1/user/summary_email/enable'
+
+payload = {
+  'auth_token': 'EXAMPLE_AUTH_TOKEN',
+  'email': 'EXAMPLE_USER_EMAIL'
+}
+
+r = requests.post(url, data=payload)
+
+print(r.json())
+```
+
+:::
+
+::::
+
+::: api-response
+```json
+{
+  "msg": "Successfully enabled summary email for email <user_email>",
   "result": "success"
 }
 ```

--- a/docs/users/management.md
+++ b/docs/users/management.md
@@ -120,21 +120,6 @@ endpoints:
         type: string
         description: The email address of the user to be enabled
     response: JSON structure with result indicator.
-  enable_user_summary_email:
-    name: Enable User Summary Email
-    url: /api/v1/user/summary_email/enable
-    method: POST
-    description: Enables summary email notifications for a specified user. Admins may enable summary emails for any user, but regular users may only enable summary emails for themselves.
-    params:
-      - name: auth_token
-        required: true
-        type: string
-        description: A valid auth token
-      - name: email
-        required: true
-        type: string
-        description: The email address of the user whose summary emails should be enabled
-    response: JSON structure with result indicator.
   disable_user_2fa:
     name: Disable User's TOTP
     url: /api/v1/user/2fa/disable
@@ -289,6 +274,21 @@ endpoints:
         required: true
         type: string
         description: The email address of the user whose summary emails should be disabled
+    response: JSON structure with result indicator.
+  enable_user_summary_email:
+    name: Enable User Summary Email
+    url: /api/v1/user/summary_email/enable
+    method: POST
+    description: Enables summary email notifications for a specified user. Admins may enable summary emails for any user, but regular users may only enable summary emails for themselves.
+    params:
+      - name: auth_token
+        required: true
+        type: string
+        description: A valid auth token
+      - name: email
+        required: true
+        type: string
+        description: The email address of the user whose summary emails should be enabled
     response: JSON structure with result indicator.
 ---
 

--- a/resources/ignored_endpoints
+++ b/resources/ignored_endpoints
@@ -42,8 +42,6 @@
 /user/password/change
 /user/2fa/enable
 /user/2fa/verify
-/user/summary_email/disable
-/user/summary_email/
 
 # requires logged in user
 /webauthn/add_authenticator


### PR DESCRIPTION
## Proposed changes

The documentation for `/api/v1/settings/notifications/summary_email/save` was misleading. This endpoint only sets email addresses to receive summary emails if those email addresses are not associated with registered users. We add documentation explaining this.

If you want a registered user to receive summary emails the endpoints

- `/api/v1/user/summary_email/disable`
- `/api/v1/user/summary_email/enable`

should be used. We add documentation for those endpoints.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion